### PR TITLE
Use SHA for CI dependencies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # tag=v3.6.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # tag=v4.9.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # tag=v4.3.0
       - name: List all files
         run: ls -a
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # tag=v4.9.0
         with:
           python-version: '3.12'
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # tag=v1.0.7
         with:
           toolchain: stable
           override: true


### PR DESCRIPTION
For increased security, it is recommended to pin actions to a specific commit using its SHA ([source](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)).

If we later use Dependabot, it can update the SHAs and the corresponding comments.