### PR TITLE
Add dependabot setup for Rust and Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        # patch and minor updates don't matter for libraries as consumers of this library build
+        # with their own lockfile, rather than the version specified in this library's lockfile
+        # remove this ignore rule if your package has binaries to ensure that the binaries are
+        # built with the exact set of dependencies and those are up to date.
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Adds a dependabot template from <https://github.com/jonhoo/rust-ci-conf/>. Dependabot automatically opens PRs to update dependencies, hence keeping them up-to-date.

I have not added Python to the config because I would like to wait for the switch to a `pyproject.toml` file first. Extending the Dependabot config can happen in a separate PR, though.

**It probably makes sense to merge #48 first.**