### PR TITLE
Rename crate to synir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn",
 ]
 
 [[package]]
@@ -556,6 +556,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "2.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synir"
 version = "0.1.0"
 dependencies = [
  "bitvec",
@@ -564,17 +575,6 @@ dependencies = [
  "petgraph",
  "rand",
  "typenum",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -646,7 +646,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -668,7 +668,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -809,5 +809,5 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "syn"
+name = "synir"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SYN
+# synIR
 
 
 
@@ -20,7 +20,7 @@ make python_project_setup
 
 ### Rust
 
-This project requires [rust](), please follow the guidelines for installation.
+This project requires rust, please follow the guidelines for installation.
 
 To run the basic rust setup, run:
 

--- a/benches/clifford_tableau.rs
+++ b/benches/clifford_tableau.rs
@@ -2,14 +2,13 @@ use crate::connectivity::connectivity_benchmark;
 use bitvec::bitvec;
 use bitvec::prelude::Lsb0;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use syn::data_structures::CliffordTableau;
-use syn::data_structures::PauliString;
-use syn::ir::clifford_tableau::naive::NaiveCliffordSynthesizer;
-use syn::ir::clifford_tableau::CallbackCliffordSynthesizer;
-use syn::ir::CliffordGates;
-use syn::ir::Synthesizer;
-
-mod connectivity;
+use synir::data_structures::CliffordTableau;
+use synir::data_structures::PauliString;
+use synir::ir::clifford_tableau::naive::NaiveCliffordSynthesizer;
+use synir::ir::clifford_tableau::CallbackCliffordSynthesizer;
+use synir::ir::CliffordGates;
+use synir::ir::Synthesizer;
+use synir::IndexType;
 
 mod connectivity;
 
@@ -44,43 +43,43 @@ impl MockCircuit {
 }
 
 impl CliffordGates for MockCircuit {
-    fn s(&mut self, target: syn::IndexType) {
+    fn s(&mut self, target: IndexType) {
         self.commands.push(MockCommand::S(target));
     }
 
-    fn v(&mut self, target: syn::IndexType) {
+    fn v(&mut self, target: IndexType) {
         self.commands.push(MockCommand::V(target));
     }
 
-    fn s_dgr(&mut self, target: syn::IndexType) {
+    fn s_dgr(&mut self, target: IndexType) {
         self.commands.push(MockCommand::SDgr(target));
     }
 
-    fn v_dgr(&mut self, target: syn::IndexType) {
+    fn v_dgr(&mut self, target: IndexType) {
         self.commands.push(MockCommand::VDgr(target));
     }
 
-    fn x(&mut self, target: syn::IndexType) {
+    fn x(&mut self, target: IndexType) {
         self.commands.push(MockCommand::X(target));
     }
 
-    fn y(&mut self, target: syn::IndexType) {
+    fn y(&mut self, target: IndexType) {
         self.commands.push(MockCommand::Y(target));
     }
 
-    fn z(&mut self, target: syn::IndexType) {
+    fn z(&mut self, target: IndexType) {
         self.commands.push(MockCommand::Z(target));
     }
 
-    fn h(&mut self, target: syn::IndexType) {
+    fn h(&mut self, target: IndexType) {
         self.commands.push(MockCommand::H(target));
     }
 
-    fn cx(&mut self, control: syn::IndexType, target: syn::IndexType) {
+    fn cx(&mut self, control: IndexType, target: IndexType) {
         self.commands.push(MockCommand::CX(control, target));
     }
 
-    fn cz(&mut self, control: syn::IndexType, target: syn::IndexType) {
+    fn cz(&mut self, control: IndexType, target: IndexType) {
         self.commands.push(MockCommand::CZ(control, target));
     }
 }

--- a/benches/connectivity.rs
+++ b/benches/connectivity.rs
@@ -3,8 +3,8 @@ use petgraph::visit::Walker;
 use rand::prelude::IndexedRandom;
 use rand::seq::SliceRandom;
 use rand::Rng;
-use syn::architecture::connectivity::Connectivity;
-use syn::architecture::Architecture;
+use synir::architecture::connectivity::Connectivity;
+use synir::architecture::Architecture;
 
 fn random_connected_connectivity(
     num_nodes: usize,

--- a/synpy/Cargo.toml
+++ b/synpy/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 [dependencies]
 bitvec = "1.0.1"
 pyo3 = "0.23.3"
-syn = { path = "../" }
+synir = { path = "../" }

--- a/synpy/src/synthesis.rs
+++ b/synpy/src/synthesis.rs
@@ -1,16 +1,19 @@
-use std::ops::Deref;
-use pyo3::{pyfunction, PyRef, PyResult};
 use pyo3::exceptions::PyException;
 use pyo3::{pyclass, pymethods, PyErr};
-use syn::data_structures::{CliffordTableau, PauliPolynomial};
-use syn::data_structures::PropagateClifford;
-use syn::ir::clifford_tableau::CliffordTableauSynthStrategy;
-use syn::ir::CliffordGates;
-use syn::ir::Gates;
-use syn::ir::pauli_exponential::{PauliExponential, PauliExponentialSynthesizer};
-use syn::ir::pauli_polynomial::PauliPolynomialSynthStrategy;
+use std::ops::Deref;
+
+use pyo3::{pyfunction, PyRef, PyResult};
+use synir::data_structures::PropagateClifford;
+use synir::data_structures::{CliffordTableau, PauliPolynomial};
+use synir::ir::clifford_tableau::CliffordTableauSynthStrategy;
+use synir::ir::pauli_exponential::{PauliExponential, PauliExponentialSynthesizer};
+use synir::ir::pauli_polynomial::PauliPolynomialSynthStrategy;
+use synir::ir::CliffordGates;
+use synir::ir::Gates;
+use synir::ir::Synthesizer;
+use synir::IndexType;
+
 use crate::validation::validate;
-use syn::ir::Synthesizer;
 
 #[pyclass]
 #[derive(Debug, Copy, Clone)]
@@ -137,63 +140,63 @@ impl CommandCollector {
         }
     }
 
-    pub fn commands(&self) -> Vec<PyCommand>  {
+    pub fn commands(&self) -> Vec<PyCommand> {
         self.commands.clone()
     }
 }
 
 impl CliffordGates for CommandCollector {
-    fn s(&mut self, target: syn::IndexType) {
+    fn s(&mut self, target: IndexType) {
         self.commands.push(PyCommand::S(target));
     }
 
-    fn v(&mut self, target: syn::IndexType) {
+    fn v(&mut self, target: IndexType) {
         self.commands.push(PyCommand::V(target));
     }
 
-    fn s_dgr(&mut self, target: syn::IndexType) {
+    fn s_dgr(&mut self, target: IndexType) {
         self.commands.push(PyCommand::SDgr(target));
     }
 
-    fn v_dgr(&mut self, target: syn::IndexType) {
+    fn v_dgr(&mut self, target: IndexType) {
         self.commands.push(PyCommand::VDgr(target));
     }
 
-    fn x(&mut self, target: syn::IndexType) {
+    fn x(&mut self, target: IndexType) {
         self.commands.push(PyCommand::X(target));
     }
 
-    fn y(&mut self, target: syn::IndexType) {
+    fn y(&mut self, target: IndexType) {
         self.commands.push(PyCommand::Y(target));
     }
 
-    fn z(&mut self, target: syn::IndexType) {
+    fn z(&mut self, target: IndexType) {
         self.commands.push(PyCommand::Z(target));
     }
 
-    fn h(&mut self, target: syn::IndexType) {
+    fn h(&mut self, target: IndexType) {
         self.commands.push(PyCommand::H(target));
     }
 
-    fn cx(&mut self, control: syn::IndexType, target: syn::IndexType) {
+    fn cx(&mut self, control: IndexType, target: IndexType) {
         self.commands.push(PyCommand::CX(control, target));
     }
 
-    fn cz(&mut self, control: syn::IndexType, target: syn::IndexType) {
+    fn cz(&mut self, control: IndexType, target: IndexType) {
         self.commands.push(PyCommand::CZ(control, target));
     }
 }
 
 impl Gates for CommandCollector {
-    fn rx(&mut self, target: syn::IndexType, angle: f64) {
+    fn rx(&mut self, target: IndexType, angle: f64) {
         self.commands.push(PyCommand::Rx(target, angle));
     }
 
-    fn ry(&mut self, target: syn::IndexType, angle: f64) {
+    fn ry(&mut self, target: IndexType, angle: f64) {
         self.commands.push(PyCommand::Ry(target, angle));
     }
 
-    fn rz(&mut self, target: syn::IndexType, angle: f64) {
+    fn rz(&mut self, target: IndexType, angle: f64) {
         self.commands.push(PyCommand::Rz(target, angle));
     }
 }

--- a/synpy/src/tableau.rs
+++ b/synpy/src/tableau.rs
@@ -4,12 +4,11 @@ use bitvec::prelude::BitVec;
 use pyo3::basic::CompareOp;
 use pyo3::prelude::*;
 use pyo3::PyResult;
-use syn::data_structures::CliffordTableau as CliffordTableau;
-use syn::data_structures::PauliString;
-use syn::data_structures::PropagateClifford;
-
-use syn::ir::clifford_tableau::NaiveCliffordSynthesizer;
-use syn::ir::Synthesizer;
+use synir::data_structures::CliffordTableau;
+use synir::data_structures::PauliString;
+use synir::data_structures::PropagateClifford;
+use synir::ir::clifford_tableau::NaiveCliffordSynthesizer;
+use synir::ir::Synthesizer;
 
 #[pyclass(unsendable)]
 pub struct PyCliffordTableau {

--- a/tests/clifford_tableau.rs
+++ b/tests/clifford_tableau.rs
@@ -3,9 +3,9 @@ mod common;
 use bitvec::bitvec;
 use bitvec::prelude::Lsb0;
 use common::{parse_clifford_commands, MockCircuit, MockCommand};
-use syn::data_structures::{CliffordTableau, PauliString, PropagateClifford};
-use syn::ir::clifford_tableau::{CallbackCliffordSynthesizer, NaiveCliffordSynthesizer};
-use syn::ir::{AdjointSynthesizer, Synthesizer};
+use synir::data_structures::{CliffordTableau, PauliString, PropagateClifford};
+use synir::ir::clifford_tableau::{CallbackCliffordSynthesizer, NaiveCliffordSynthesizer};
+use synir::ir::{AdjointSynthesizer, Synthesizer};
 
 fn setup_sample_ct() -> CliffordTableau {
     // Stab: ZZZ, -YIY, XIX

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,7 @@
-use syn::{
+use synir::{
     data_structures::{CliffordTableau, PropagateClifford},
     ir::{CliffordGates, Gates},
+    IndexType,
 };
 
 type Angle = f64;
@@ -38,57 +39,57 @@ impl MockCircuit {
 }
 
 impl CliffordGates for MockCircuit {
-    fn s(&mut self, target: syn::IndexType) {
+    fn s(&mut self, target: IndexType) {
         self.commands.push(MockCommand::S(target));
     }
 
-    fn v(&mut self, target: syn::IndexType) {
+    fn v(&mut self, target: IndexType) {
         self.commands.push(MockCommand::V(target));
     }
 
-    fn s_dgr(&mut self, target: syn::IndexType) {
+    fn s_dgr(&mut self, target: IndexType) {
         self.commands.push(MockCommand::SDgr(target));
     }
 
-    fn v_dgr(&mut self, target: syn::IndexType) {
+    fn v_dgr(&mut self, target: IndexType) {
         self.commands.push(MockCommand::VDgr(target));
     }
 
-    fn x(&mut self, target: syn::IndexType) {
+    fn x(&mut self, target: IndexType) {
         self.commands.push(MockCommand::X(target));
     }
 
-    fn y(&mut self, target: syn::IndexType) {
+    fn y(&mut self, target: IndexType) {
         self.commands.push(MockCommand::Y(target));
     }
 
-    fn z(&mut self, target: syn::IndexType) {
+    fn z(&mut self, target: IndexType) {
         self.commands.push(MockCommand::Z(target));
     }
 
-    fn h(&mut self, target: syn::IndexType) {
+    fn h(&mut self, target: IndexType) {
         self.commands.push(MockCommand::H(target));
     }
 
-    fn cx(&mut self, control: syn::IndexType, target: syn::IndexType) {
+    fn cx(&mut self, control: IndexType, target: IndexType) {
         self.commands.push(MockCommand::CX(control, target));
     }
 
-    fn cz(&mut self, control: syn::IndexType, target: syn::IndexType) {
+    fn cz(&mut self, control: IndexType, target: IndexType) {
         self.commands.push(MockCommand::CZ(control, target));
     }
 }
 
 impl Gates for MockCircuit {
-    fn rx(&mut self, target: syn::IndexType, angle: Angle) {
+    fn rx(&mut self, target: IndexType, angle: Angle) {
         self.commands.push(MockCommand::Rx(target, angle));
     }
 
-    fn ry(&mut self, target: syn::IndexType, angle: Angle) {
+    fn ry(&mut self, target: IndexType, angle: Angle) {
         self.commands.push(MockCommand::Ry(target, angle));
     }
 
-    fn rz(&mut self, target: syn::IndexType, angle: Angle) {
+    fn rz(&mut self, target: IndexType, angle: Angle) {
         self.commands.push(MockCommand::Rz(target, angle));
     }
 }

--- a/tests/pauli_exponential.rs
+++ b/tests/pauli_exponential.rs
@@ -3,12 +3,12 @@ mod common;
 use std::collections::VecDeque;
 
 use common::{parse_clifford_commands, MockCircuit, MockCommand};
-use syn::data_structures::{CliffordTableau, PauliPolynomial};
-use syn::ir::clifford_tableau::{CliffordTableauSynthStrategy, NaiveCliffordSynthesizer};
-use syn::ir::pauli_exponential::PauliExponential;
-use syn::ir::pauli_exponential::PauliExponentialSynthesizer;
-use syn::ir::pauli_polynomial::PauliPolynomialSynthStrategy;
-use syn::ir::Synthesizer;
+use synir::data_structures::{CliffordTableau, PauliPolynomial};
+use synir::ir::clifford_tableau::{CliffordTableauSynthStrategy, NaiveCliffordSynthesizer};
+use synir::ir::pauli_exponential::PauliExponential;
+use synir::ir::pauli_exponential::PauliExponentialSynthesizer;
+use synir::ir::pauli_polynomial::PauliPolynomialSynthStrategy;
+use synir::ir::Synthesizer;
 
 fn setup_simple_pe() -> PauliExponential {
     let ham = vec![("IZZZ", 0.3)];

--- a/tests/pauli_polynomial.rs
+++ b/tests/pauli_polynomial.rs
@@ -3,9 +3,9 @@ mod common;
 use std::collections::VecDeque;
 
 use common::{parse_clifford_commands, MockCircuit, MockCommand};
-use syn::data_structures::{CliffordTableau, PauliPolynomial};
-use syn::ir::pauli_polynomial::NaivePauliPolynomialSynthesizer;
-use syn::ir::Synthesizer;
+use synir::data_structures::{CliffordTableau, PauliPolynomial};
+use synir::ir::pauli_polynomial::NaivePauliPolynomialSynthesizer;
+use synir::ir::Synthesizer;
 
 fn setup_complex_pp() -> VecDeque<PauliPolynomial> {
     let ham_1 = vec![("IZZZ", 0.3)];


### PR DESCRIPTION
This PR changes the name in Cargo.toml and all usages. Note that the crate name can be independent of the folder name (the latter is still "syn" because that's the name of the repository).

Closes #51 